### PR TITLE
Add Terraform configuration for GKE cluster and storage bucket

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "5.34.0"
+  hashes = [
+    "h1:t48NNfGkdHByEWWiKx6GtlZPlzEB1Dha3cq44Uidev0=",
+    "zh:143c88bb74631041c291ebf7b6213467bf376d3775a33815785939dc102fac09",
+    "zh:1616ac79345f472b33fcc388eaf4a8a3002e4cc3a5e8748d60d6f4786d0d16dc",
+    "zh:554ce78e73349ac2c893a74b6981f5e55169ca16f4d0f239e6ccdecadbe1c9e1",
+    "zh:8022f97aa907685b2eb6c39d5411cf2be2448c6f3b7fbeaf9c06618d376ac4bc",
+    "zh:85f1fe3628954c35379cc05b895091ec8fe8ba0a5610bc9660492d5be65d4902",
+    "zh:873fb64fca79695aa930cd868b41ac498809eb76bc3292e41460d916c6fa3538",
+    "zh:8d3c5112a4abf14b42d769f78373e66f2c2f5f03a7e6544d80019a695bd9b198",
+    "zh:93cbcfa38991965b976d1973bc528d666006b5247c3fda00c714d0f3a2b62d3e",
+    "zh:b7710246637aee522a4ea4c1b4f0effb83b701546124ae90c8b4afb97ce03aba",
+    "zh:e4e02fe946ccbe192b6bbc6bed5715cf68084f1faadc134ed99d5e732429d2ca",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb6b1e4fb2d019d2740aa21b5ecd5f0609f562633a78604a96c14c94aff762b4",
+  ]
+}

--- a/terraform/gke-cluster.tf
+++ b/terraform/gke-cluster.tf
@@ -1,0 +1,17 @@
+resource "google_container_cluster" "primary" {
+  name     = "personal-project-cluster"
+  location = var.region
+
+  node_pool {
+    name       = "default-pool"
+    node_count = 1 # Minimal node count to save cost
+
+    node_config {
+      machine_type = "e2-medium" # Use a cost-effective machine type
+
+      oauth_scopes = [
+        "https://www.googleapis.com/auth/cloud-platform",
+      ]
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/node-pool.tf
+++ b/terraform/node-pool.tf
@@ -1,0 +1,14 @@
+resource "google_container_node_pool" "additional_nodes" {
+  cluster    = google_container_cluster.primary.name
+  location   = google_container_cluster.primary.location
+  name       = "extra-nodes-pool"
+  node_count = 1
+
+  node_config {
+    machine_type = "e2-medium"
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "kubernetes_cluster_name" {
+  description = "The name of the Kubernetes cluster"
+  value       = google_container_cluster.primary.name
+}
+
+output "bucket_name" {
+  description = "The name of the storage bucket"
+  value       = google_storage_bucket.static_assets.name
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  credentials = file(var.credentials_file)
+  project     = var.project
+  region      = var.region
+}

--- a/terraform/storage-bucket.tf
+++ b/terraform/storage-bucket.tf
@@ -1,0 +1,19 @@
+resource "google_storage_bucket" "static_assets" {
+  name          = "personal-project-static-assets"
+  location      = "US"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age = 365 # Example lifecycle rule to save costs by deleting old files
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "project" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "credentials_file" {
+  description = "Path to the GCP credentials JSON file"
+  type        = string
+}
+


### PR DESCRIPTION
This pull request adds Terraform configuration for creating a GKE cluster and a storage bucket. The GKE cluster is named "personal-project-cluster" and has a single node pool with a machine type of "e2-medium". The storage bucket is named "personal-project-static-assets" and is located in the US region. The configuration also includes variables for the GCP project ID, region, and credentials file path.